### PR TITLE
Change to provide more informative message

### DIFF
--- a/doccheck.py
+++ b/doccheck.py
@@ -30,8 +30,8 @@ def check_docstring(f):
         warnings.simplefilter('error')
         try:
             parsed = NumpyDocString(inspect.getdoc(f))
-        except:
-            print('ERROR PARSING DOCSTRING: %s' % fullname(f))
+        except UserWarning as err:
+            print('{}: {}'.format(err, fullname(f)))
             print('')
             return False
 


### PR DESCRIPTION
The change will report back the precise error from numpydoc checking. For instance "Unknown section Paramaters" instead of the unspecific message "ERROR PARSING DOCSTRING".