### PR TITLE
Python 3 compatibility

### DIFF
--- a/doccheck.py
+++ b/doccheck.py
@@ -45,7 +45,7 @@ def check_docstring(f):
     doc_args = set(iter_docargs())
 
     try:
-        argspec = inspect.getargspec(f)
+        argspec = inspect.getfullargspec(f)
     except TypeError as e:
         return False
 
@@ -58,7 +58,7 @@ def check_docstring(f):
     # the docstring might legitimately mention parameters that aren't in
     # the signature if the function takes *args, or **kwargs
     if args != doc_args and len(doc_args) > len(args) and (
-            (argspec.varargs is not None) or (argspec.keywords is not None)):
+            (argspec.varargs is not None) or (argspec.varkw is not None)):
         return False
 
     # if doc_params != args and len(parsed['Parameters']) > 0:


### PR DESCRIPTION
The function[`inspect.getargspec`](https://docs.python.org/3.5/library/inspect.html#inspect.getargspec)
has been deprecated and replaced by [`inspect.getfullargspec`](https://docs.python.org/3.5/library/inspect.html#inspect.getfullargspec).

Fixing this made this wonderful package work for me in python3.9! 
I figure it's not maintained anymore, but I have not found this functionality anywhere else! 

I think it would be nice to adapt it to also work with the latest python features.
An example that comes to mind is checking whether the given defaults are documented.